### PR TITLE
Release/v0.5.0

### DIFF
--- a/Inasync.PrimitiveAssert.Tests/IssueTests.cs
+++ b/Inasync.PrimitiveAssert.Tests/IssueTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Inasync.Tests {
@@ -146,6 +147,13 @@ namespace Inasync.Tests {
 
                 IEnumerator IEnumerable.GetEnumerator() => _source.GetEnumerator();
             }
+        }
+
+        [TestMethod]
+        public void Issue20_Test() {
+            var actual = new[] { 1, 3, 2 }.OrderBy(x => x);
+
+            actual.AssertIs(new[] { 1, 2, 3 });
         }
     }
 }

--- a/Inasync.PrimitiveAssert.Tests/IssueTests.cs
+++ b/Inasync.PrimitiveAssert.Tests/IssueTests.cs
@@ -53,7 +53,7 @@ namespace Inasync.Tests {
 
                 static Action TestCase<T>(int testNo, T x, object y, Type? expectedException = null) => () => {
                     TestAA
-                        .Act(() => x.AssertIs(y))
+                        .Act(() => x.AssertIs(y, $"No.{testNo}"))
                         .Assert(expectedException, message: $"No.{testNo}");
                 };
 

--- a/Inasync.PrimitiveAssert.Tests/IssueTests.cs
+++ b/Inasync.PrimitiveAssert.Tests/IssueTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Inasync.Tests {
@@ -93,6 +95,56 @@ namespace Inasync.Tests {
                 public string Value { get; }
                 string IFoo.Value => _fooValue;
                 string IBar.Value => _barValue;
+            }
+        }
+
+        [TestMethod]
+        public void Issue19_Test() {
+            var actual = new {
+                Foo = 1,
+                Bar = 2,
+            };
+
+            TestAA.Act(() => actual.AssertIs(new { Foo = 1 })).Assert<PrimitiveAssertFailedException>();  // expected がターゲット型を満たしていないので失敗
+            TestAA.Act(() => actual.AssertIs(new { Foo = 1, Bar = 2 })).Assert();  // actual と expected が完全一致してるので成功
+            TestAA.Act(() => actual.AssertIs(new { Foo = 1, Bar = 2, Baz = 3 })).Assert<PrimitiveAssertFailedException>();  // expected がターゲット型と完全に一致していないので失敗
+        }
+
+        [TestMethod]
+        public void Issue19_2_Test() => Issue19_2.Test();
+
+        private static class Issue19_2 {
+
+            public static void Test() {
+                static Action TestCase(int testNo, Type targetType, object x, object y, Type? expectedException = null) => () => {
+                    TestAA
+                        .Act(() => x.AssertIs(targetType, y))
+                        .Assert(expectedException, message: $"No.{testNo}");
+                };
+
+                var array = new[] { 1, 2, 3 };
+                var custom = new CustomEnumerable<int>(new[] { 1, 2, 3 });
+                new[] {
+                    TestCase( 0, targetType: typeof(IEnumerable)          , x: array , y: custom, expectedException: typeof(PrimitiveAssertFailedException)),  // 失敗：ターゲット型と expected が一致していない
+                    TestCase( 1, targetType: typeof(IEnumerable)          , x: custom, y: array ),  // 成功
+                    TestCase( 2, targetType: typeof(CustomEnumerable<int>), x: array , y: custom, expectedException: typeof(PrimitiveAssertFailedException)),  // 失敗：actual をターゲット型にダックキャストできない
+                    TestCase( 3, targetType: typeof(CustomEnumerable<int>), x: custom, y: array , expectedException: typeof(PrimitiveAssertFailedException)),  // 失敗：ターゲット型と expected が一致していない
+                    TestCase( 4, targetType: typeof(CustomEnumerable<int>), x: custom, y: custom),  // 成功
+                }.Invoke();
+            }
+
+            private class CustomEnumerable<T> : IEnumerable<T> {
+                private readonly IEnumerable<T> _source;
+
+                public CustomEnumerable(IEnumerable<T> source) {
+                    _source = source ?? throw new ArgumentNullException(nameof(source));
+                }
+
+                public string? CustomValue { get; set; }
+
+                public IEnumerator<T> GetEnumerator() => _source.GetEnumerator();
+
+                IEnumerator IEnumerable.GetEnumerator() => _source.GetEnumerator();
             }
         }
     }

--- a/Inasync.PrimitiveAssert.Tests/PrimitiveAssertTests_AssertIs.cs
+++ b/Inasync.PrimitiveAssert.Tests/PrimitiveAssertTests_AssertIs.cs
@@ -10,12 +10,8 @@ namespace Inasync.Tests {
 
         private static Action TestCase(int testNo, Type? target, object? x, object? y, Type? expectedException = null) => () => {
             TestAA
-                .Act(() => x.AssertIs(target, y, message: $"No.{testNo}_a"))
+                .Act(() => x.AssertIs(target, y))
                 .Assert(expectedException, message: $"No.{testNo}_a");
-
-            TestAA
-                .Act(() => y.AssertIs(target, x, message: $"No.{testNo}_b"))
-                .Assert(expectedException, message: $"No.{testNo}_b");
         };
 
         [TestMethod]
@@ -58,9 +54,10 @@ namespace Inasync.Tests {
             new[] {
                 TestCase( 0, target: typeof(int)    , x: 1   , y: 1   ),
                 TestCase( 1, target: typeof(int)    , x: 1   , y: 1.1m, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。
-                TestCase( 2, target: typeof(int)    , x: 1.1d, y: 1.1m),  // ターゲット型が int や double 等の数値型の場合は、小数を含む任意の数値を表す Numeric 型扱いとなる。
-                TestCase( 3, target: typeof(int)    , x: 1   , y: ""  , expectedException: typeof(PrimitiveAssertFailedException)),  // 型の不一致。
-                TestCase(10, target: typeof(int?)   , x: 1   , y: 1   ),  // ターゲット型が数値型の Nullable の場合も Numeric 型扱い。
+                TestCase( 2, target: typeof(int)    , x: 1.1d, y: 1.1m),  // ターゲット型が int や double 等の数値型の場合は、小数を含む任意の数値を表す Numeric 扱いとなる。
+                TestCase( 3, target: typeof(int)    , x: 1   , y: ""  , expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。
+                TestCase( 4, target: typeof(int)    , x: ""  , y: 1   , expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。string 型は Numeric ではない。
+                TestCase(10, target: typeof(int?)   , x: 1   , y: 1   ),  // ターゲット型が数値型の Nullable の場合も Numeric 扱い。
                 TestCase(20, target: typeof(double) , x: 1   , y: 1.0m),
                 TestCase(30, target: typeof(decimal), x: 1m  , y: 1.0m),
             }.Invoke();
@@ -73,7 +70,7 @@ namespace Inasync.Tests {
             var dummy = new DummyStruct();
             new[] {
                 TestCase( 0, target: typeof(Guid)  , x: guid1, y: guid1),
-                TestCase( 1, target: typeof(Guid)  , x: guid1, y: dummy, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。DummyStruct 型は基本データ型ではない。
+                TestCase( 1, target: typeof(Guid)  , x: guid1, y: dummy, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。
                 TestCase( 2, target: typeof(Guid)  , x: dummy, y: guid1, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。DummyStruct 型は基本データ型ではない。
                 TestCase( 3, target: typeof(Guid)  , x: guid1, y: guid2, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。
                 TestCase(10, target: typeof(string), x: guid1, y: guid1, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。string 型に Guid 値は割り当てられない。
@@ -88,7 +85,7 @@ namespace Inasync.Tests {
                 TestCase( 0, target: typeof(IEnumerable), x: new[]{1,2}, y: new[]{1,2}),
                 TestCase( 1, target: typeof(IEnumerable), x: new[]{1,2}, y: new[]{1  }, expectedException: typeof(PrimitiveAssertFailedException)),  // 要素数の不一致。
                 TestCase( 2, target: typeof(IEnumerable), x: new[]{1,2}, y: new[]{1,3}, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。
-                TestCase( 3, target: typeof(IEnumerable), x: new[]{1,2}, y: 1         , expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。IEnumerable 型に int 値は割り当てられない。
+                TestCase( 3, target: typeof(IEnumerable), x: new[]{1,2}, y: 1         , expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。
                 TestCase( 4, target: typeof(IEnumerable), x: 1         , y: new[]{1,2}, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。IEnumerable 型に int 値は割り当てられない。
 
                 TestCase(10, target: typeof(string)     , x: new[]{'a','b'}    , y: new[]{'a','b'}    , expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。string 型に char[] 値は割り当てられない。
@@ -97,8 +94,13 @@ namespace Inasync.Tests {
 
                 TestCase(20, target: countType          , x: new int[]    {1,2}, y: new{Count=2}, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。Array は {Count:int} 匿名型を (ダック的に) 満たしていない (Count 等の明示的実装は比較されない)
                 TestCase(21, target: countType          , x: new List<int>{1,2}, y: new{Count=2}),
-                TestCase(22, target: typeof(ICollection), x: new List<int>{1,2}, y: new{Count=2}, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。{Count:int} 匿名値は ICollection 型を (ダック的に) 満たしていない (SyncRoot とか)。
+                TestCase(22, target: typeof(ICollection), x: new List<int>{1,2}, y: new{Count=2}, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。
                 TestCase(23, target: typeof(ICollection), x: new List<int>{1,2}, y: new[]{1,2}  ),
+
+                TestCase(30, target: countType          , x: new{Count=2}, y: new int[]    {1,2}, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。Array に Count データメンバーが無い。
+                TestCase(31, target: countType          , x: new{Count=2}, y: new List<int>{1,2}, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。countType と List<T> のデータメンバーが一致しない。
+                TestCase(32, target: typeof(ICollection), x: new{Count=2}, y: new List<int>{1,2}, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。{Count:int} 匿名型はコレクションをダック的に満たしていない。
+                TestCase(33, target: typeof(ICollection), x: new[]{1,2}  , y: new List<int>{1,2}),
             }.Invoke();
         }
 
@@ -111,12 +113,17 @@ namespace Inasync.Tests {
             new[] {
                 TestCase( 0, target: typeof(DummyClass), x:dummy, y:dummy               ),
                 TestCase( 1, target: typeof(DummyClass), x:dummy, y:DummyClass()        ),
-                TestCase( 2, target: typeof(DummyClass), x:dummy, y:new{ReadOnlyField=1}, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。{ReadOnlyField:int} 匿名値は DummyClass 型を (ダック的に) 満たしていない。
+                TestCase( 2, target: typeof(DummyClass), x:dummy, y:new{ReadOnlyField=1}, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。{ReadOnlyField:int} 匿名値は DummyClass 型とデータメンバーが一致しない。
                 TestCase( 3, target: fooType           , x:dummy, y:dummy               , expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。DummyClass 値は {Foo:int} 匿名型を (ダック的に) 満たしていない。
-                TestCase(10, target: readOnlyFieldType , x:dummy, y:DummyClass()        ),
+                TestCase(10, target: readOnlyFieldType , x:dummy, y:DummyClass()        , expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。y はダックキャストされていないので、x に対して余分なデータメンバーが存在する。
                 TestCase(11, target: readOnlyFieldType , x:dummy, y:new{ReadOnlyField=1}),
-                TestCase(12, target: typeof(object)    , x:dummy, y:new{}               ),  // issue #10: ターゲット型が object の場合データ メンバーが存在しない為、実質検証なし。
-                TestCase(13, target: typeof(object)    , x:dummy, y:new{Foo=0}          ),  // issue #10: ターゲット型が object の場合データ メンバーが存在しない為、実質検証なし。
+                TestCase(12, target: typeof(object)    , x:dummy, y:new{}               ),  // issue #10: ターゲット型が object の場合データ メンバーが存在しない。
+                TestCase(13, target: typeof(object)    , x:dummy, y:new{Foo=0}          , expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致、y はダックキャストされていないので、x に対して余分なデータメンバーが存在する。
+
+                TestCase(20, target: typeof(DummyClass), x:new{ReadOnlyField=1}, y:dummy, expectedException: typeof(PrimitiveAssertFailedException)),  // ターゲット型違反。{ReadOnlyField:int} 匿名値は DummyClass 型を（ダックタイプ的に）満たしていない。
+                TestCase(21, target: readOnlyFieldType , x:new{ReadOnlyField=1}, y:dummy, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。y はダックキャストされていないので、x に対して余分なデータメンバーが存在する。
+                TestCase(22, target: typeof(object)    , x:new{}               , y:dummy, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。y はダックキャストされていないので、x に対して余分なデータメンバーが存在する。
+                TestCase(23, target: typeof(object)    , x:new{Foo=0}          , y:dummy, expectedException: typeof(PrimitiveAssertFailedException)),  // 値の不一致。y はダックキャストされていないので、x に対して余分なデータメンバーが存在する。
 
                 TestCase(50, target: typeof(IList<int>[]), x:new[]{new List<int>{1,2}, new List<int>{3}}, y:new[]{new[]{1,2}, new[]{3}}),
             }.Invoke();
@@ -167,7 +174,8 @@ namespace Inasync.Tests {
                 LastError = new ApplicationException(),
             };
 
-            TestCase(0, target: x.GetType(), x: x, y: y)();
+            x.AssertIs(y);
+            y.AssertIs(x);
         }
 
         [TestMethod]
@@ -180,7 +188,8 @@ namespace Inasync.Tests {
 
             new[] {
                 TestCase( 0, x: new{ Foo=1, Bar="B" }, y: new{ Foo=1 }         , expectedException: typeof(PrimitiveAssertFailedException)),
-                TestCase( 1, x: new{ Foo=1 }         , y: new{ Foo=1, Bar="B" }),
+                TestCase(14, x: new{ Foo=1, Bar="B" }, y: new{ Foo=1, Bar="B" }),
+                TestCase( 1, x: new{ Foo=1 }         , y: new{ Foo=1, Bar="B" }, expectedException: typeof(PrimitiveAssertFailedException)),
                 TestCase( 2, x: new List<int>{ 1, 2 }, y: new[]{ 1, 2 }        ),  // issue #3: List<T> 等の汎用コレクションは複合型アサートを行わない (List<T> なら Capacity をアサートしない)
                 TestCase( 3, x: new[]{ 1, 2 }        , y: new List<int>{ 1, 2 }),  // issue #6: 配列や Array も汎用コレクションとして、複合型アサートは行わない。
                 TestCase( 4, x: new DummyStruct[0]   , y: new List<DummyStruct>()), // issue #7: System 名前空間かどうかは配列判定に関係なかったので、適切な配列判定に修正。

--- a/Inasync.PrimitiveAssert.Tests/PrimitiveAssertTests_AssertIs.cs
+++ b/Inasync.PrimitiveAssert.Tests/PrimitiveAssertTests_AssertIs.cs
@@ -10,8 +10,8 @@ namespace Inasync.Tests {
 
         private static Action TestCase(int testNo, Type? target, object? x, object? y, Type? expectedException = null) => () => {
             TestAA
-                .Act(() => x.AssertIs(target, y))
-                .Assert(expectedException, message: $"No.{testNo}_a");
+                .Act(() => x.AssertIs(target, y, $"No.{testNo}"))
+                .Assert(expectedException, message: $"No.{testNo}");
         };
 
         [TestMethod]

--- a/Inasync.PrimitiveAssert.Tests/PrimitiveSerializerTests.cs
+++ b/Inasync.PrimitiveAssert.Tests/PrimitiveSerializerTests.cs
@@ -29,9 +29,8 @@ namespace Inasync.Tests {
                 LastError = new ApplicationException(),
             };
 
-            var json = x.ToPrimitiveString();
-
-            Console.WriteLine(json);
+            Console.WriteLine(x.ToPrimitiveString(pretty: false));
+            Console.WriteLine(x.ToPrimitiveString(pretty: true));
         }
     }
 }

--- a/Inasync.PrimitiveAssert.Tests/PrimitiveSerializerTests.cs
+++ b/Inasync.PrimitiveAssert.Tests/PrimitiveSerializerTests.cs
@@ -7,7 +7,7 @@ namespace Inasync.Tests {
     public class PrimitiveSerializerTests {
 
         [TestMethod]
-        public void Usage() {
+        public void ToPrimitiveString_Usage() {
             var x = new {
                 AccountId = new Guid("f5b63bc6-9876-4e07-8400-f06daf3e4212"),
                 FullName = "John Smith",
@@ -27,10 +27,11 @@ namespace Inasync.Tests {
                 Params2 = (ValueTuple<int, string>?)null,
                 Params3 = Tuple.Create(1, "bar"),
                 LastError = new ApplicationException(),
+                StringType = typeof(string),
             };
 
-            Console.WriteLine(x.ToPrimitiveString(pretty: false));
-            Console.WriteLine(x.ToPrimitiveString(pretty: true));
+            Console.WriteLine(x.ToPrimitiveString(indented: false));
+            Console.WriteLine(x.ToPrimitiveString(indented: true));
         }
     }
 }

--- a/Inasync.PrimitiveAssert/Commons/DictionaryExtensions.cs
+++ b/Inasync.PrimitiveAssert/Commons/DictionaryExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Inasync {
+namespace Commons {
 
     internal static class DictionaryExtensions {
 

--- a/Inasync.PrimitiveAssert/Commons/EnumerableExtensions.cs
+++ b/Inasync.PrimitiveAssert/Commons/EnumerableExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Commons {
+
+    internal static class EnumerableExtensions {
+
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source) {
+            return new HashSet<T>(source);
+        }
+    }
+}

--- a/Inasync.PrimitiveAssert/Commons/TypeExtensions.cs
+++ b/Inasync.PrimitiveAssert/Commons/TypeExtensions.cs
@@ -55,5 +55,27 @@ namespace Commons {
                    .SelectMany(x => x.GetProperties(bindingAttr))
                    ;
         }
+
+        /// <summary>
+        /// 判りやすい型名を返します。
+        /// </summary>
+        /// <param name="type">対象の型。</param>
+        /// <returns><paramref name="type"/> を判別しやすい型名。</returns>
+        public static string GetFriendlyName(this Type type) {
+            if (type.IsGenericType) {
+                string genericTypeName = type.Name.IndexOf('`') switch
+                {
+                    { } i when i >= 0 => type.Name.Remove(i),
+                    _ => type.Name,
+                };
+                return $"{genericTypeName}<{string.Join(", ", type.GetGenericArguments().Select(x => x.GetFriendlyName()))}>";
+            }
+
+            if (type.IsArray) {
+                return type.GetElementType().GetFriendlyName() + "[]";
+            }
+
+            return type.Name;
+        }
     }
 }

--- a/Inasync.PrimitiveAssert/Inasync.PrimitiveAssert.csproj
+++ b/Inasync.PrimitiveAssert/Inasync.PrimitiveAssert.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/in-async/PrimitiveAssert</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/in-async/PrimitiveAssert/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>library test unittest assert deep</PackageTags>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Inasync.PrimitiveAssert/Internals/AssertIsImpl.cs
+++ b/Inasync.PrimitiveAssert/Internals/AssertIsImpl.cs
@@ -21,7 +21,7 @@ namespace Inasync {
             var actual = node.Actual;
             var expected = node.Expected;
 
-            _logger?.Write($"{node.MemberName}: {node.TargetType.ToPrimitiveString()} = ");
+            _logger?.Write($"{node.MemberName}: {node.TargetType?.GetFriendlyName() ?? "(null)"} = ");
             try {
                 // null 比較
                 if (targetType is null) {

--- a/Inasync.PrimitiveAssert/Internals/AssertIsImpl.cs
+++ b/Inasync.PrimitiveAssert/Internals/AssertIsImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.CodeDom.Compiler;
 using System.Collections;
 using System.Linq;
 using Commons;
@@ -7,9 +8,9 @@ namespace Inasync {
 
     internal readonly struct AssertIsImpl {
         private readonly string? _message;
-        private readonly Action<string>? _logger;
+        private readonly IndentedTextWriter? _logger;
 
-        public AssertIsImpl(string? message, Action<string>? logger) {
+        public AssertIsImpl(string? message, IndentedTextWriter? logger) {
             _message = message;
             _logger = logger;
         }
@@ -20,44 +21,62 @@ namespace Inasync {
             var actual = node.Actual;
             var expected = node.Expected;
 
-            // null 比較
-            if (targetType is null) {
-                if (!(actual is null)) { throw new PrimitiveAssertFailedException(node, "ターゲット型は null ですが、actual は非 null です。", _message); }
-                if (!(expected is null)) { throw new PrimitiveAssertFailedException(node, "actual は null ですが、expected は非 null です。", _message); }
+            _logger?.Write($"{node.MemberName}: {node.TargetType.ToPrimitiveString()} = ");
+            try {
+                // null 比較
+                if (targetType is null) {
+                    if (!(actual is null)) { throw new PrimitiveAssertFailedException(node, "ターゲット型は null ですが、actual は非 null です。", _message); }
+                    if (!(expected is null)) { throw new PrimitiveAssertFailedException(node, "actual は null ですが、expected は非 null です。", _message); }
 
-                WriteLog(node, "actual と expected はどちらも null です。");
-                return;
-            }
-            if (targetType.IsValueType && !targetType.IsNullable()) {
-                if (actual is null) { throw new PrimitiveAssertFailedException(node, "ターゲット型は null 非許容型ですが、actual は null です。", _message); }
-            }
-            if (actual is null) {
-                if (expected is null) {
                     WriteLog(node, "actual と expected はどちらも null です。");
                     return;
                 }
-                else { throw new PrimitiveAssertFailedException(node, "actual は null ですが、expected が非 null です。", _message); }
+                if (targetType.IsValueType && !targetType.IsNullable()) {
+                    if (actual is null) { throw new PrimitiveAssertFailedException(node, "ターゲット型は null 非許容型ですが、actual は null です。", _message); }
+                }
+                if (actual is null) {
+                    if (expected is null) {
+                        WriteLog(node, "actual と expected はどちらも null です。");
+                        return;
+                    }
+                    else { throw new PrimitiveAssertFailedException(node, "actual は null ですが、expected が非 null です。", _message); }
+                }
+                else {
+                    if (expected is null) { throw new PrimitiveAssertFailedException(node, "actual は非 null ですが、expected が null です。", _message); }
+                }
+
+                if (TryNumericAssertIs(targetType, actual, expected, node)) { return; }
+                if (TryPrimitiveAssertIs(targetType, actual, expected, node)) { return; }
+                if (TryReferenceAssertIs(targetType, actual, expected, node)) { return; }
+                if (TryCircularReferenceAssertIs(targetType, actual, expected, node)) { return; }
             }
-            else {
-                if (expected is null) { throw new PrimitiveAssertFailedException(node, "actual は非 null ですが、expected が null です。", _message); }
+            catch (PrimitiveAssertFailedException) {
+                _logger?.WriteLine();
+                throw;
             }
 
-            if (TryNumericAssertIs(targetType, actual, expected, node)) { return; }
-            if (TryPrimitiveAssertIs(targetType, actual, expected, node)) { return; }
-            if (TryReferenceAssertIs(targetType, actual, expected, node)) { return; }
-            if (TryCircularReferenceAssertIs(targetType, actual, expected, node)) { return; }
-            if (TryCollectionAssertIs(targetType, actual, expected, node)) { return; }
-            if (TryCompositeAssertIs(targetType, actual, expected, node)) { return; }
+            if (_logger != null) {
+                _logger.WriteLine("{");
+                _logger.Indent++;
+            }
+            if (TryCollectionAssertIs(targetType, actual, expected, node)) { goto EndBlock; }
+            if (TryCompositeAssertIs(targetType, actual, expected, node)) { goto EndBlock; }
+EndBlock:
+            if (_logger != null) {
+                _logger.Indent--;
+                _logger.WriteLine("}");
+            }
+            return;
         }
 
         private void WriteLog(AssertNode node, string additionalMessage) {
             if (_logger == null) { return; }
 
-            if (_message != null) {
-                _logger(_message);
+            _logger.Write(node.Actual.ToPrimitiveString());
+            if (additionalMessage != null) {
+                _logger.Write("    // " + additionalMessage);
             }
-            _logger(additionalMessage);
-            _logger(node.ToString());
+            _logger.WriteLine();
         }
 
         private bool TryNumericAssertIs(Type targetType, object actual, object expected, AssertNode node) {
@@ -76,7 +95,7 @@ namespace Inasync {
             if (!targetType.IsInstanceOfType(actual)) { throw new PrimitiveAssertFailedException(node, "ターゲット型は基本データ型ですが、actual はターゲット型に違反しています。", _message); }
             if (!actual.Equals(expected)) { throw new PrimitiveAssertFailedException(node, $"actual と expected は基本データ型として等しくありません。", _message); }
 
-            WriteLog(node, $"actual と expected は {targetType.Name} 型として等しいです。");
+            WriteLog(node, $"actual と expected は {targetType.GetFriendlyName()} 型として等しいです。");
             return true;
         }
 
@@ -101,7 +120,7 @@ namespace Inasync {
                     if (ReferenceEquals(parent.Expected, expected)) {
                         if (!actualType.IsDuckImplemented(targetType)) { throw new PrimitiveAssertFailedException(node, "actual と expected は同じパスに対する循環参照ですが、ターゲット型に違反しています。", _message); }
 
-                        WriteLog(node, $"actual と expected は同じパスに対する循環参照です。{Environment.NewLine}循環先のパス: {parent.Path}");
+                        WriteLog(node, $"actual と expected は同じパスに対する循環参照です。循環先のパス: {parent.Path}");
                         return true;
                     }
                     else { throw new PrimitiveAssertFailedException(node, "actual は循環参照ですが、expected が循環参照ではありません。", _message); }
@@ -120,8 +139,8 @@ namespace Inasync {
             var actualType = actual.GetType();
             var expectedType = expected.GetType();
 
-            if (!(actual is IEnumerable)) { throw new PrimitiveAssertFailedException(node, $"ターゲット型 {targetType} はコレクション型ですが、actual の型 {actualType} は非コレクション型です。", _message); }
-            if (!(expected is IEnumerable)) { throw new PrimitiveAssertFailedException(node, $"actual はコレクション型ですが、expected の型 {expectedType} は非コレクション型です。", _message); }
+            if (!(actual is IEnumerable)) { throw new PrimitiveAssertFailedException(node, $"ターゲット型 {targetType.GetFriendlyName()} はコレクション型ですが、actual の型 {actualType.GetFriendlyName()} は非コレクション型です。", _message); }
+            if (!(expected is IEnumerable)) { throw new PrimitiveAssertFailedException(node, $"actual はコレクション型ですが、expected の型 {expectedType.GetFriendlyName()} は非コレクション型です。", _message); }
             var actualItems = ((IEnumerable)actual).AsCollection();
             var expectedItems = ((IEnumerable)expected).AsCollection();
             if (actualItems.Count != expectedItems.Count) { throw new PrimitiveAssertFailedException(node, $"actual の要素数 {actualItems.Count} と expected の要素数 {expectedItems.Count} が等しくありません。", _message); }
@@ -135,7 +154,7 @@ namespace Inasync {
 
                 // NOTE: 要素型が不明の場合は、要素のランタイム型にフォールバック。
                 var itemTargetType = itemType ?? actualIter.Current?.GetType();
-                AssertIs(new AssertNode(i.ToString(), itemTargetType, actualIter.Current, expectedIter.Current, node));
+                AssertIs(new AssertNode("[" + i + "]", itemTargetType, actualIter.Current, expectedIter.Current, node));
             }
             if (!targetType.IsSystemCollection()) { return false; }
             if (!expectedType.IsSystemCollection()) { return false; }
@@ -158,8 +177,8 @@ namespace Inasync {
             var targetDataMembers = targetType.GetDataMembers().ToArray();
             var duplicateMember = targetDataMembers.ToLookup(x => x.Name).FirstOrDefault(g => g.Count() > 1);
             if (duplicateMember != null) {
-                var duplicateMemberNames = duplicateMember.Select(x => $"'{x.DeclaringType.Name}.{x.Name}'");
-                throw new ArgumentException(message: $"ターゲット型 '{targetType.Name}' に含まれる {string.Join(" と ", duplicateMemberNames)} があいまいです。");
+                var duplicateMemberNames = duplicateMember.Select(x => $"'{x.DeclaringType.GetFriendlyName()}.{x.Name}'");
+                throw new ArgumentException(message: $"ターゲット型 '{targetType.GetFriendlyName()}' に含まれる {string.Join(" と ", duplicateMemberNames)} があいまいです。");
             }
 
             // 各データ メンバーの比較

--- a/Inasync.PrimitiveAssert/Internals/AssertNode.cs
+++ b/Inasync.PrimitiveAssert/Internals/AssertNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Commons;
 
 namespace Inasync {
 
@@ -12,12 +13,12 @@ namespace Inasync {
             Parent = parent;
 
             if (parent == null) {
-                Path = ".";
+                Path = "actual";
             }
             else {
                 Path = parent.Path + "/" + memberName;
                 if (targetType != null) {
-                    Path += ":" + targetType.Name;
+                    Path += ":" + targetType.GetFriendlyName();
                 }
             }
         }
@@ -31,9 +32,9 @@ namespace Inasync {
 
         public override string ToString() => $@"{{
       path: {Path}
-    target: {TargetType?.FullName ?? "(null)"}
-    actual: {Actual ?? "(null)"}
-  expected: {Expected ?? "(null)"}
+    target: {TargetType.ToPrimitiveString()}
+    actual: {Actual.ToPrimitiveString()}
+  expected: {Expected.ToPrimitiveString()}
 }}";
     }
 }

--- a/Inasync.PrimitiveAssert/Internals/Numeric.cs
+++ b/Inasync.PrimitiveAssert/Internals/Numeric.cs
@@ -48,7 +48,8 @@ namespace Inasync {
         }
 
         public override bool Equals(object? obj) {
-            return obj is Numeric numeric && Equals(numeric);
+            if (obj == null) { return false; }
+            return TryCreate(obj, out var numeric) && Equals(numeric);
         }
 
         public bool Equals(Numeric other) {

--- a/Inasync.PrimitiveAssert/Internals/TypeExtensions.cs
+++ b/Inasync.PrimitiveAssert/Internals/TypeExtensions.cs
@@ -88,7 +88,7 @@ namespace Inasync {
             if (duckType.IsAssignableFrom(type)) { return true; }
 
             var targetMembers = type.GetDataMembers().Select(x => x.Name);
-            var duckMemberSet = new HashSet<string>(duckType.GetDataMembers().Select(x => x.Name));
+            var duckMemberSet = duckType.GetDataMembers().Select(x => x.Name).ToHashSet();
             return duckMemberSet.IsSubsetOf(targetMembers);
         }
     }

--- a/Inasync.PrimitiveAssert/Internals/TypeExtensions.cs
+++ b/Inasync.PrimitiveAssert/Internals/TypeExtensions.cs
@@ -52,6 +52,7 @@ namespace Inasync {
             {
                 "System.Collections" => true,
                 "System.Collections.Generic" => true,
+                "System.Linq" => true,
                 _ => false,
             };
         }

--- a/Inasync.PrimitiveAssert/PrimitiveAssert.cs
+++ b/Inasync.PrimitiveAssert/PrimitiveAssert.cs
@@ -37,7 +37,6 @@ namespace Inasync {
         /// <param name="message">検証に失敗した際に、例外に含まれるメッセージ。</param>
         /// <exception cref="PrimitiveAssertFailedException"><paramref name="actual"/> と <paramref name="expected"/> が等価ではありません。</exception>
         /// <exception cref="ArgumentException">ターゲット型に同じ名前のデータメンバーが 2 つ以上存在します。</exception>
-        /// <remarks><paramref name="actual"/> と <paramref name="expected"/> に対して対称式となります。</remarks>
         public static void AssertIs<TTarget>(this object? actual, object? expected, string? message = null) {
             actual.AssertIs(typeof(TTarget), expected, message);
         }
@@ -52,7 +51,6 @@ namespace Inasync {
         /// <param name="message">検証に失敗した際に、例外に含まれるメッセージ。</param>
         /// <exception cref="PrimitiveAssertFailedException"><paramref name="actual"/> と <paramref name="expected"/> が等価ではありません。</exception>
         /// <exception cref="ArgumentException">ターゲット型に同じ名前のデータメンバーが 2 つ以上存在します。</exception>
-        /// <remarks><paramref name="actual"/> と <paramref name="expected"/> に対して対称式となります。</remarks>
         public static void AssertIs(this object? actual, Type? targetType, object? expected, string? message = null) {
             var assert = new AssertIsImpl(message, ConsoleLogging ? _consoleLogger : null);
             assert.AssertIs(new AssertNode(memberName: "", targetType: targetType, actual, expected, parent: null));

--- a/Inasync.PrimitiveAssert/PrimitiveAssertFailedException.cs
+++ b/Inasync.PrimitiveAssert/PrimitiveAssertFailedException.cs
@@ -13,7 +13,12 @@ namespace Inasync {
         /// <param name="message">エラーを説明するメッセージ。</param>
         public PrimitiveAssertFailedException(string? message) : base(message) { }
 
-        internal PrimitiveAssertFailedException(AssertNode node, string reason, string? message) : base($@"{message}: {reason}
-{node}") { }
+        internal PrimitiveAssertFailedException(AssertNode node, string reason, string? message) : base($"{message}: {reason}{Environment.NewLine}{node}") {
+            Reason = reason;
+            Node = node;
+        }
+
+        internal AssertNode? Node { get; }
+        internal string? Reason { get; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -88,35 +88,14 @@ PrimitiveAssert.ConsoleLogging = true;
 ```
 とする事で、次のようなログがコンソールに出力されます:
 ```
-{
-      path: ./AccountId:Int32
-    target: System.Int32
-    actual: 123
-  expected: 123
-}
-{
-      path: ./Name:String
-    target: System.String
-    actual: John Smith
-  expected: John Smith
-}
-{
-      path: ./CreatedAt:DateTime
-    target: System.DateTime
-    actual: 2020/03/09 8:15:00
-  expected: 2020/03/09 8:15:00
-}
-{
-      path: ./Tags:IReadOnlyCollection`1/0:String
-    target: System.String
-    actual: Foo
-  expected: Foo
-}
-{
-      path: ./Tags:IReadOnlyCollection`1/1:String
-    target: System.String
-    actual: Bar
-  expected: Bar
+actual: IAccount = {
+    AccountId: Int32 = 123    // actual と expected は数値型として等しいです。
+    Name: String = "John Smith"    // actual と expected は String 型として等しいです。
+    CreatedAt: DateTime = "2020/03/09 8:15:00"    // actual と expected は DateTime 型として等しいです。
+    Tags: IReadOnlyCollection<String> = {
+        [0]: String = "Foo"    // actual と expected は String 型として等しいです。
+        [1]: String = "Bar"    // actual と expected は String 型として等しいです。
+    }
 }
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,6 @@ deploy:
     appveyor_repo_tag: true
 - provider: NuGet
   api_key:
-    secure: EoZxNktAkUB1WAqUGi03AWD1Xg6vNK5MfpWn9ifG/tRZmz+z3vNceafx1VjBRgTL
+    secure: DHHwPl58vYq4Cai+Ub7NvEZYZY4FGq1XGlIG2yXjvTE4cVyGtXpZWbcA0akbZqC8
   on:
     appveyor_repo_tag: true


### PR DESCRIPTION
Changes:
* #18 ConsoleLogging の出力と PrimitiveAssertFailedException のメッセージを改善。
* #19 ターゲット型と expected のデータメンバーが一致しないとアサートに失敗するよう変更。
* #20 System.Linq 下のコレクション型もシステム コレクションとして扱うよう修正。
* #2 PrimitiveSerializer のシグネチャとシリアライズ形式を改善。