### PR TITLE
Release/v0.7.1

### DIFF
--- a/Inasync.PrimitiveAssert.Tests/IssueTests.cs
+++ b/Inasync.PrimitiveAssert.Tests/IssueTests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -176,6 +177,18 @@ namespace Inasync.Tests {
         public void Issue24_Test() {
             new ConcurrentQueue<int>(new[] { 1, 2 }).AssertIs(new[] { 1, 2 });
             new ConcurrentStack<int>(new[] { 1, 2 }).AssertIs(new[] { 2, 1 });
+        }
+
+        [TestMethod]
+        public void Issue27_Test() {
+            new ReadOnlyCollection<int>(new[] { 1, 2, }).AssertIs(new[] { 1, 2, });
+            new ReadOnlyDictionary<int, string>(new Dictionary<int, string> {
+                { 1, "a" },
+                { 2, "b" },
+            }).AssertIs(new Dictionary<int, string> {
+                { 1, "a" },
+                { 2, "b" },
+            });
         }
     }
 }

--- a/Inasync.PrimitiveAssert/Inasync.PrimitiveAssert.csproj
+++ b/Inasync.PrimitiveAssert/Inasync.PrimitiveAssert.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/in-async/PrimitiveAssert</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/in-async/PrimitiveAssert/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>library test unittest assert deep</PackageTags>
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/Inasync.PrimitiveAssert/Internals/TypeExtensions.cs
+++ b/Inasync.PrimitiveAssert/Internals/TypeExtensions.cs
@@ -46,6 +46,7 @@ namespace Inasync {
         /// <see cref="System.Collections.Generic"/>,
         /// <see cref="System.Collections.Concurrent"/>,
         /// <see cref="System.Linq"/>,
+        /// <see cref="System.Collections.ObjectModel"/>
         /// のいずれかの名前空間に属する <see cref="IEnumerable"/> 実装を指します。
         /// </para>
         /// </summary>
@@ -59,6 +60,7 @@ namespace Inasync {
                 "System.Collections.Generic" => true,
                 "System.Collections.Concurrent" => true,
                 "System.Linq" => true,
+                "System.Collections.ObjectModel" => true,
                 _ => false,
             };
         }


### PR DESCRIPTION
Changes:
* #27 `System.Collections.ObjectModel` 名前空間にある IEnumerable 実装を汎用コレクションとして扱うよう更新。